### PR TITLE
Decode checkbox value from json when value is fetch from db.

### DIFF
--- a/src/fields/Checkboxes.php
+++ b/src/fields/Checkboxes.php
@@ -63,4 +63,18 @@ class Checkboxes extends Field
             'options' => $options,
         ]);
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function normalizeValue($value, ElementInterface $element = null)
+    {
+        if (is_string($value)) {
+            $value = Json::decodeIfJson($value);
+        } else if ($value === null && $this->isFresh($element)) {
+            $value = [];
+        }
+
+        return (array)$value;
+    }
 }


### PR DESCRIPTION
In twig2 non of the array expecting methods work so
it is not possible to iterate over the result.

Twig2 operator `in`, used in the template works but only by chance
as it is searching for a string.